### PR TITLE
Add code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -8,7 +8,7 @@ We are committed to creating a friendly and respectful place for learning, teach
 All participants in our events and communications are expected to show respect and courtesy to others.
 
 To make clear what is expected, everyone participating in Childhood Cancer Data Lab (CCDL) training activities is required to conform to the Code of Conduct.
-This Code of Conduct applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter.
+This Code of Conduct applies to all spaces managed by the CCDL including, but not limited to, training workshops, videoconferences, email lists, and online forums such as GitHub, Slack and Twitter.
 
 If you feel harassed or treated inappropriately at any time, please contact the Director of the CCDL at [ccdl@alexslemonade.org](mailto:ccdl@alexslemonade.org).
 


### PR DESCRIPTION
This PR adds the code of conduct. We should probably link to it from the wiki, but I think that may require this to merge in first.

Closes #1 

