### PR TITLE
Pre Workshop R Prep Markdown

### DIFF
--- a/R-prep.md
+++ b/R-prep.md
@@ -18,7 +18,7 @@ swirl::install_course("Getting and Cleaning Data")
 If you are interested in even more material, the [full list of swirl courses is here](https://swirlstats.com/scn/title.html)
 
 #### *More resources for learning R*
-*No need to complete all of this before the workshop, but if you want more resources.*
+*Here are some more resources for those of you who want to dive deeper. It is NOT mandatory to go through these for the workshop*
 + [R for Data Science](https://r4ds.had.co.nz/)  
 + [R Markdown](http://rmarkdown.rstudio.com)  
 + [Tutorial on R, RStudio and R Markdown](https://ismayc.github.io/rbasics-book/)  


### PR DESCRIPTION
### Background 

This closes https://github.com/alexslemonade/training-admin/issues/205 

We need a document that we can link to that has the R prep that we recommend our participants complete before the workshop. 

Next step will be to put a link to this both in the wiki as well as the week out email. See https://github.com/alexslemonade/training-admin/issues/174 

### Questions: 
Is it too overwhelming to have the other resource links at the end? How do I word that so it is clear that we aren't telling them they need to go through all the materials before the workshop but are just there in case they'd like more materials? 
