### PR TITLE
Docker image with relevant dependencies for this training

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,14 +36,17 @@ RUN R -e "BiocManager::install(c('ensembldb', 'DESeq2', 'qvalue',\
 RUN apt update && apt install -y fastqc
 
 # fastp 
+ENV FASTP_VERSION 0.20.1
 RUN git clone https://github.com/OpenGene/fastp.git
 RUN cd fastp && \
+    git checkout tags/v${FASTP_VERSION} -b v${FASTP_VERSION} && \
     make && \
     sudo make install
 
 # MultiQC
+ENV MULTIQC_VERSION 1.8
 RUN apt update && apt install -y python3-pip
-RUN pip3 install multiqc
+RUN pip3 install multiqc==${MULTIQC_VERSION}
 
 ENV PACKAGES git gcc make g++ libboost-all-dev liblzma-dev libbz2-dev \
     ca-certificates zlib1g-dev curl unzip autoconf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,76 @@
+FROM rocker/tidyverse:3.6.1
+MAINTAINER ccdl@alexslemonade.org
+WORKDIR /rocker-build/
+
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+RUN apt-get install dialog apt-utils -y
+
+RUN apt-get update -qq && apt-get -y --no-install-recommends install \
+    build-essential \
+    libxml2-dev \
+    libsqlite-dev \
+    libmariadbd-dev \
+    libmariadbclient-dev \
+    libmariadb-client-lgpl-dev \
+    libpq-dev \
+    libssh2-1-dev \
+    pandoc \
+    libmagick++-dev \
+    time
+
+RUN install2.r \
+    rjson \ 
+    ggpubr \
+    colorspace\
+    Rtsne \
+    umap
+
+ENV BIOCONDUCTOR_VERSION 3.10
+RUN R -e "BiocManager::install(c('ensembldb', 'DESeq2', 'qvalue',\
+    'org.Hs.eg.db', 'org.Dr.eg.db', 'org.Mm.eg.db', 'org.Cf.eg.db',\
+    'ComplexHeatmap', 'ConsensusClusterPlus', 'scran', 'scater',\
+    'tximport', 'alevinQC'), \
+    version = '${BIOCONDUCTOR_VERSION}', update = FALSE)"
+
+# FastQC
+RUN apt update && apt install -y fastqc
+
+# fastp 
+RUN git clone https://github.com/OpenGene/fastp.git
+RUN cd fastp && \
+    make && \
+    sudo make install
+
+# MultiQC
+RUN apt update && apt install -y python-pip
+RUN pip install multiqc
+
+ENV PACKAGES git gcc make g++ libboost-all-dev liblzma-dev libbz2-dev \
+    ca-certificates zlib1g-dev curl unzip autoconf
+
+ENV CMAKE_VERSION 3.17.2
+ENV SALMON_VERSION 1.2.1
+
+# salmon binary will be installed in /home/salmon/bin/salmon
+# don't modify things below here for version updates etc.
+
+WORKDIR /home
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ${PACKAGES} && \
+    apt-get clean
+
+# Apt doesn't have the latest version of cmake, so install it using their script.
+RUN apt remove cmake cmake-data -y
+
+RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
+    mkdir /opt/cmake && \
+    sh cmake-${CMAKE_VERSION}-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
+    sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+
+RUN curl -k -L https://github.com/COMBINE-lab/salmon/archive/v${SALMON_VERSION}.tar.gz -o salmon-v${SALMON_VERSION}.tar.gz && \
+    tar xzf salmon-v${SALMON_VERSION}.tar.gz && \
+    cd salmon-${SALMON_VERSION} && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local && make && make install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,8 +42,8 @@ RUN cd fastp && \
     sudo make install
 
 # MultiQC
-RUN apt update && apt install -y python-pip
-RUN pip install multiqc
+RUN apt update && apt install -y python3-pip
+RUN pip3 install multiqc
 
 ENV PACKAGES git gcc make g++ libboost-all-dev liblzma-dev libbz2-dev \
     ca-certificates zlib1g-dev curl unzip autoconf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,29 +51,14 @@ RUN pip3 install multiqc==${MULTIQC_VERSION}
 ENV PACKAGES git gcc make g++ libboost-all-dev liblzma-dev libbz2-dev \
     ca-certificates zlib1g-dev curl unzip autoconf
 
-ENV CMAKE_VERSION 3.17.2
 ENV SALMON_VERSION 1.2.1
-
-# salmon binary will be installed in /home/salmon/bin/salmon
-# don't modify things below here for version updates etc.
-
 WORKDIR /home
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ${PACKAGES} && \
     apt-get clean
 
-# Apt doesn't have the latest version of cmake, so install it using their script.
-RUN apt remove cmake cmake-data -y
-
-RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
-    mkdir /opt/cmake && \
-    sh cmake-${CMAKE_VERSION}-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
-
-RUN curl -k -L https://github.com/COMBINE-lab/salmon/archive/v${SALMON_VERSION}.tar.gz -o salmon-v${SALMON_VERSION}.tar.gz && \
-    tar xzf salmon-v${SALMON_VERSION}.tar.gz && \
-    cd salmon-${SALMON_VERSION} && \
-    mkdir build && \
-    cd build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local && make && make install
+RUN wget https://github.com/COMBINE-lab/salmon/releases/download/v${SALMON_VERSION}/salmon-${SALMON_VERSION}_linux_x86_64.tar.gz
+RUN tar xzf salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
+    rm -f salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
+    sudo ln -s /home/salmon-latest_linux_x86_64/bin/salmon /usr/local/bin/salmon


### PR DESCRIPTION
This doesn't currently build because of the following error:

```
[100%] Linking CXX executable salmon
../../external/install/lib/libstaden-read.a(libstaden_read_la-open_trace_file.o): In function `find_file_url':
open_trace_file.c:(.text+0xd69): warning: the use of `tempnam' is dangerous, better use `mkstemp'
../external/pufferfish/src/libpuffer.a(PufferfishIndexer.cpp.o): In function `std::shared_ptr<spdlog::logger> spdlog::details::registry_t<std::mutex>::create<__gnu_cxx::__normal_iterator<std::shared_ptr<spdlog::sinks::sink>*, std::vector<std::shared_ptr<spdlog::sinks::sink>, std::allocator<std::shared_ptr<spdlog::sinks::sink> > > > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, __gnu_cxx::__normal_iterator<std::shared_ptr<spdlog::sinks::sink>*, std::vector<std::shared_ptr<spdlog::sinks::sink>, std::allocator<std::shared_ptr<spdlog::sinks::sink> > > > const&, __gnu_cxx::__normal_iterator<std::shared_ptr<spdlog::sinks::sink>*, std::vector<std::shared_ptr<spdlog::sinks::sink>, std::allocator<std::shared_ptr<spdlog::sinks::sink> > > > const&)':
PufferfishIndexer.cpp:(.text._ZN6spdlog7details10registry_tISt5mutexE6createIN9__gnu_cxx17__normal_iteratorIPSt10shared_ptrINS_5sinks4sinkEESt6vectorISA_SaISA_EEEEEES7_INS_6loggerEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKT_SS_[_ZN6spdlog7details10registry_tISt5mutexE6createIN9__gnu_cxx17__normal_iteratorIPSt10shared_ptrINS_5sinks4sinkEESt6vectorISA_SaISA_EEEEEES7_INS_6loggerEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKT_SS_]+0x73): undefined reference to `vtable for std::_Sp_counted_ptr_inplace<spdlog::logger, std::allocator<spdlog::logger>, (__gnu_cxx::_Lock_policy)2>'
PufferfishIndexer.cpp:(.text._ZN6spdlog7details10registry_tISt5mutexE6createIN9__gnu_cxx17__normal_iteratorIPSt10shared_ptrINS_5sinks4sinkEESt6vectorISA_SaISA_EEEEEES7_INS_6loggerEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKT_SS_[_ZN6spdlog7details10registry_tISt5mutexE6createIN9__gnu_cxx17__normal_iteratorIPSt10shared_ptrINS_5sinks4sinkEESt6vectorISA_SaISA_EEEEEES7_INS_6loggerEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKT_SS_]+0x21d): undefined reference to `vtable for std::_Sp_counted_ptr_inplace<spdlog::async_logger, std::allocator<spdlog::async_logger>, (__gnu_cxx::_Lock_policy)2>'
collect2: error: ld returned 1 exit status
make[2]: *** [src/salmon] Error 1
src/CMakeFiles/salmon.dir/build.make:441: recipe for target 'src/salmon' failed
make[1]: *** [src/CMakeFiles/salmon.dir/all] Error 2
CMakeFiles/Makefile2:650: recipe for target 'src/CMakeFiles/salmon.dir/all' failed
make: *** [all] Error 2
Makefile:182: recipe for target 'all' failed
The command '/bin/sh -c curl -k -L https://github.com/COMBINE-lab/salmon/archive/v${SALMON_VERSION}.tar.gz -o salmon-v${SALMON_VERSION}.tar.gz &&     tar xzf salmon-v${SALMON_VERSION}.tar.gz &&     cd salmon-${SALMON_VERSION} &&     mkdir build &&     cd build &&     cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local && make && make install' returned a non-zero code: 2
```
I have been able to successfully build using the binary, e.g.:

```
WORKDIR /home
ENV SALMON_VERSION 1.2.1
RUN wget https://github.com/COMBINE-lab/salmon/releases/download/v${SALMON_VERSION}/salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
  tar xzf salmon-${SALMON_VERSION}_linux_x86_64.tar.gz && \
  rm -f salmon-${SALMON_VERSION}_linux_x86_64.tar.gz
```

And I can invoke the following (yes this shows up as `salmon-latest` maybe that is the problem...I think that is a problem when rolling back to `1.2.0`, too):

```
/home/salmon-latest_linux_x86_64/bin/salmon swim
```

But I have not successfully added it to the path as of yet. I have tried the following (with different permutations of quotes and some other things that I did not take great notes on involving `root/.bashrc`)

```
ENV PATH=/home/salmon_${SALMON_VERSION}_linux_x86_64/bin:$PATH
```

And some things with `etc/environment` per: https://github.com/COMBINE-lab/salmon/blob/91091fc3650a3220f657a9f31616916513f0ad02/docker/Dockerfile#L49

Filing this to get some input!